### PR TITLE
Resolves #1: Update PHP requirement to allow versions past 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^7.0",
+        "php": ">=7.0",
         "ext-mbstring": "*"
     },
     "require-dev": {


### PR DESCRIPTION
I confirmed that markdown-table is compatible with PHP 8.1 by running `composer update --ignore-platform-reqs` and then testing things out.